### PR TITLE
sync _get_instances with updated nitter instances wiki page

### DIFF
--- a/ntscraper/nitter.py
+++ b/ntscraper/nitter.py
@@ -98,7 +98,7 @@ class Nitter:
             soup = BeautifulSoup(r.text, "lxml")
             official = soup.find_all("tbody")[0]
             instance_list.append(official.find("a")["href"])
-            table = soup.find_all("tbody")[1]
+            table = soup.find_all("tbody")[2]
             for instance in table.find_all("tr"):
                 columns = instance.find_all("td")
                 if (columns[1].text.strip() == "✅") and (


### PR DESCRIPTION
Nitter Instances wiki had a breaking change that introduced a new table called [Third-party Nitter services](https://github.com/zedeus/nitter/wiki/Instances/1e1766e74761a09b104b57076a153f560528ebdb#third-party-nitter-services) before the [Public](https://github.com/zedeus/nitter/wiki/Instances/1e1766e74761a09b104b57076a153f560528ebdb#public) table, which breaks ntscraper. This pull request updates the [Public](https://github.com/zedeus/nitter/wiki/Instances/1e1766e74761a09b104b57076a153f560528ebdb#public) table's index in `_get_instances`.