### PR TITLE
Account is protected message

### DIFF
--- a/ntscraper/nitter.py
+++ b/ntscraper/nitter.py
@@ -193,7 +193,10 @@ class Nitter:
                     + soup.find("div", class_="error-panel").find("span").text.strip()
                 )
             else:
-                message = f"Empty page on {self.instance}"
+                if soup.find("div", class_="timeline-header timeline-protected"):
+                    message = "Account is protected"
+                else:
+                    message = f"Empty page on {self.instance}"
             logging.warning(message)
             soup = None
         return soup


### PR DESCRIPTION
If an account is protected, one will not opt to scrape that user else, it is possible that the user doesn't have tweets only for that duration. This condition clarifies the message for a protected user.