### PR TITLE
Updated _get_user to improve profile ID extraction and error handling

### DIFF
--- a/ntscraper/nitter.py
+++ b/ntscraper/nitter.py
@@ -476,7 +476,7 @@ class Nitter:
         :param is_encrypted: True if instance uses encrypted media
         :return: dictionary of user
         """
-        avatar = "https://pbs.twimg.com/default_avatar.png"  # Default avatar
+        avatar = "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"  # Default avatar
         profile_id = "unknown"  # Default profile ID
 
         if is_encrypted:
@@ -487,14 +487,14 @@ class Nitter:
                     .encode("utf-8")
                 ).decode("utf-8")
             except:
-                avatar = "https://pbs.twimg.com/default_avatar.png"  # Fallback avatar
+                avatar = "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"  # Fallback avatar
 
         else:
             avatar_tag = tweet.find("img", class_="avatar")
             if avatar_tag and avatar_tag.has_attr("src"):
                 avatar = avatar_tag["src"]  # Successfully getting avatar
             else:
-                avatar = "https://pbs.twimg.com/default_avatar.png"  # Fallback avatar
+                avatar = "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"  # Fallback avatar
 
         # Extract profile_id directly from the avatar URL if available
         if "profile_images" in avatar:

--- a/ntscraper/nitter.py
+++ b/ntscraper/nitter.py
@@ -476,8 +476,9 @@ class Nitter:
         :param is_encrypted: True if instance uses encrypted media
         :return: dictionary of user
         """
-        avatar = ""
-        profile_id = ""
+        avatar = "https://pbs.twimg.com/default_avatar.png"  # Default avatar
+        profile_id = "unknown"  # Default profile ID
+
         if is_encrypted:
             try:
                 avatar = "https://pbs.twimg.com/" + b64decode(
@@ -486,30 +487,19 @@ class Nitter:
                     .encode("utf-8")
                 ).decode("utf-8")
             except:
-                avatar = ""
+                avatar = "https://pbs.twimg.com/default_avatar.png"  # Fallback avatar
 
-            if tweet.find("img", class_="avatar"):
-                profile_id = (
-                    b64decode(
-                        tweet.find("img", class_="avatar")["src"]
-                        .split("/enc/")[1]
-                        .encode("utf-8")
-                    )
-                    .decode("utf-8")
-                    .split("/profile_images/")[1]
-                    .split("/")[0]
-                )
         else:
-            avatar = "https://pbs.twimg.com" + unquote(
-                tweet.find("img", class_="avatar")["src"].split("/pic")[1]
-            )
+            avatar_tag = tweet.find("img", class_="avatar")
+            if avatar_tag and avatar_tag.has_attr("src"):
+                avatar = avatar_tag["src"]  # Successfully getting avatar
+            else:
+                avatar = "https://pbs.twimg.com/default_avatar.png"  # Fallback avatar
 
-            if tweet.find("img", class_="avatar"):
-                profile_id = (
-                    unquote(tweet.find("img", class_="avatar")["src"])
-                    .split("profile_images/")[1]
-                    .split("/")[0]
-                )
+        # Extract profile_id directly from the avatar URL if available
+        if "profile_images" in avatar:
+            profile_id = avatar.split("/profile_images/")[1].split("/")[0]
+
         return {
             "name": tweet.find("a", class_="fullname").text.strip(),
             "username": tweet.find("a", class_="username").text.strip(),


### PR DESCRIPTION
## What does this PR do?
This PR addresses issues in the _get_user function of the ```ntscraper``` library. The following improvements have been made:

### **Fixes & Changes:**

**Fixed ```profile_id``` Extraction:**
- Previously used ```b64decode()```, causing ```IndexError: list index out of range```.
- Now extracts ```profile_id``` directly from avatar URL if ```profile_images``` exists.

**Corrected avatar Handling:**
- Removed unnecessary ```b64decode()```, as Twitter profile URLs are not ```Base64-encoded```.
- Added a proper fallback for missing avatars (default_avatar.png).

**Improved Error Handling:**
- Added checks to prevent ```AttributeError``` when ```img``` tag is missing.
- Made it strong against unexpected URLs.

**Code Optimization & Readability:**
- Simplified extraction logic.
- Reduced redundant decoding and string manipulations.

### **Why This Fix is Needed?**
- The previous implementation caused ```IndexError: list index out of range``` due to incorrect decoding.
- This fix ensures that user data (profile picture, username, and profile ID) is extracted safely and correctly across different tweet formats.