### PR TITLE
Decode URL-encoded avatar src before extracting profile_id

### DIFF
--- a/ntscraper/nitter.py
+++ b/ntscraper/nitter.py
@@ -492,7 +492,7 @@ class Nitter:
         else:
             avatar_tag = tweet.find("img", class_="avatar")
             if avatar_tag and avatar_tag.has_attr("src"):
-                avatar = avatar_tag["src"]  # Successfully getting avatar
+                avatar = unquote(avatar_tag["src"])  # Successfully getting avatar
             else:
                 avatar = "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"  # Fallback avatar
 


### PR DESCRIPTION
## Description

This PR addresses an `IndexError` in the `_get_user` method when the avatar `src` attribute is percent-encoded. By decoding the URL before extracting the `profile_id`, we ensure the split operation always succeeds.

## Issue

When Nitter returns an avatar URL like '/pic/profile_images%2F874276197357596672%2FkUuht00m_bigger.jpg'
fails because "/profile_images/" is not found in the encoded string, causing an IndexError: list index out of range.

### Reproducible code

Reproduced with the latest Nitter instance (Docker Compose)

```python
from ntscraper import Nitter

scraper = Nitter(instances=["http://localhost:8080"], log_level=1, skip_instance_check=False)

scraper.get_tweets("realDonaldTrump", mode="user", number=2)
```

```sh
Testing instances: 100%|██████████| 1/1 [00:00<00:00,  1.73it/s]
19-May-25 15:50:29 - No instance specified, using random instance http://localhost:8080

File ~/Desktop/soju/ntscraper/ntscraper/nitter.py:436, in Nitter._get_user(self, tweet, is_encrypted)
    434 # Extract profile_id directly from the avatar URL if available
    435 if "profile_images" in avatar:
--> 436     profile_id = avatar.split("/profile_images/")[1].split("/")[0]
    438 return {
    439     "name": tweet.find("a", class_="fullname").text.strip(),
    440     "username": tweet.find("a", class_="username").text.strip(),
    441     "profile_id": profile_id,
    442     "avatar": avatar,
    443 }

IndexError: list index out of range
```

### Changes

Decode avatar_tag["src"] via unquote before assigning it to avatar

```diff
             if avatar_tag and avatar_tag.has_attr("src"):
-                avatar = avatar_tag["src"]  # Successfully getting avatar
+                avatar = unquote(avatar_tag["src"])  # Decode and get avatar
             else:
                 avatar = "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"
```
