### PR TITLE
Add tweet id field and tighten link extraction

### DIFF
--- a/ntscraper/nitter.py
+++ b/ntscraper/nitter.py
@@ -1,7 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 import random
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 from time import sleep
 from base64 import b64decode
 from random import uniform
@@ -547,9 +547,8 @@ class Nitter:
         :param tweet: tweet to extract link from
         :return: link of tweet
         """
-        return (
-            "https://twitter.com" + tweet.find("a")["href"] if tweet.find("a") else ""
-        )
+        tweet_date = tweet.find("span", class_="tweet-date")
+        return "https://twitter.com" + tweet_date.find("a")["href"] if tweet_date else ""
 
     def _get_external_link(self, tweet):
         """
@@ -616,8 +615,13 @@ class Nitter:
         # Extract media from the tweet
         pictures, videos, gifs = self._get_tweet_media(tweet, is_encrypted)
 
+        # Extract the tweet id
+        link = self._get_tweet_link(tweet)
+        id = urlparse(link).path.rsplit("/", 1)[-1]
+
         return {
-            "link": self._get_tweet_link(tweet),
+            "id": id,
+            "link": link,
             "text": self._get_tweet_text(tweet),
             "user": self._get_user(tweet, is_encrypted),
             "date": self._get_tweet_date(tweet),


### PR DESCRIPTION
## Description

This PR enhances the tweet extraction logic by adding a dedicated id field to each tweet object. The tweet ID is now parsed directly from the URL, ensuring downstream consumers can reliably reference or fetch tweets by their unique identifier. Additionally, the link-extraction method has been tightened to pull the correct \<a\> from the tweet’s date span.

### Changes
- Added urlparse from urllib.parse for URL parsing.
- Refactored _get_tweet_link to locate the \<a\> inside the span.tweet-date element instead of the first \<a\> in the tweet, preventing accidental link grabs.
- Inserted the "id": id entry into the returned dict.

### Output example

```python
from ntscraper import Nitter

scraper = Nitter(instances=["http://127.0.0.1:8080"], log_level=1, skip_instance_check=False)

scraper.get_tweet_by_id("realDonaldTrump", '1923793436068487574')
```
```sh
{'id': '1923793436068487574',  # <--- new id field
 'link': 'https://twitter.com/realDonaldTrump/status/1923793436068487574#m',  # <--- fixed link extraction
 'text': '🇦🇪🇺🇸',
 'user': {'name': 'Donald J. Trump',
  'username': '@realDonaldTrump',
  'profile_id': '874276197357596672',
  'avatar': '/pic/profile_images/874276197357596672/kUuht00m_bigger.jpg'},
 'date': 'May 17, 2025 · 5:31 PM UTC',
 'is-retweet': False,
 'is-pinned': False,
 'external-link': '',
 'replying-to': [],
 'quoted-post': {},
 'stats': {'comments': 12577,
  'retweets': 26950,
  'quotes': 1173,
  'likes': 190516},
 'pictures': [],
 'videos': [],
 'gifs': []}
```